### PR TITLE
修正翻译 11.3 Disk space

### DIFF
--- a/src/web-storage/disk-space.zh.html
+++ b/src/web-storage/disk-space.zh.html
@@ -2,8 +2,8 @@
 
   <p>用户代理应该限制可存储区域的空间大小，否则恶意的作者可能会利用这一特性耗尽用户的可用磁盘空间。</p>
 
-  <p>用户代理应该防止网站在它们源下的附属站点进行存储，例如应防范通过在
-  a1.example.com，a2.example.com，a3.example.com 等站点进行存储，
+  <p>用户代理应该防止站点在它们源下的附属站点进行存储，例如应防范通过在
+  a1.example.com、a2.example.com、a3.example.com 等站点进行存储，
   来绕过主站 example.com 存储限制的行为</p>
 
   <p>当到达配额时用户代理可以提示用户，使用户可以授予一个站点更多空间。
@@ -14,7 +14,7 @@
   <!--<p>If the storage area space limit is reached during a <code
   data-x="dom-Storage-setItem">setItem()</code> call, the method will throw an exception.</p>-->
 
-  <p>通常建议每个 <span data-x="origin">源</span> 的存储上线是 5M。
+  <p>通常建议每个 <span data-x="origin">源</span> 的存储上限是 5M。
   欢迎实现者提供反馈意见，用于将来更新这个建议。</p>
 
   <p>为了保证可预测性，配额应该基于未压缩的数据存储大小来进行计算。</p>

--- a/src/web-storage/disk-space.zh.html
+++ b/src/web-storage/disk-space.zh.html
@@ -1,23 +1,23 @@
   <h3>磁盘空间</h3>
 
-  <p>用户代理应该限制存储区域允许的空间总量，否则恶意的作者可能会利用这一特性耗尽用户的可用磁盘空间。</p>
+  <p>用户代理应该限制可存储区域的空间大小，否则恶意的作者可能会利用这一特性耗尽用户的可用磁盘空间。</p>
 
-  <p>用户代理应该防止网站在其域的子域下存储数据
-  （例如在 a1.example.com，a2.example.com，a3.example.com等）
-  来规避主域 example.com 的存储限制。com storage limit.</p>
+  <p>用户代理应该防止网站在它们源下的附属站点进行存储，例如应防范通过在
+  a1.example.com，a2.example.com，a3.example.com 等站点进行存储，
+  来绕过主站 example.com 存储限制的行为</p>
 
   <p>当到达配额时用户代理可以提示用户，使用户可以授予一个站点更多空间。
-  例如，这可以支持在用户电脑中存储很多用户创建的文档的站点。</p>
+  例如，这可以允许站点在用户电脑中存储很多用户创建的文档。</p>
 
   <p>用户代理应该允许用户看到每个域名使用的空间大小。</p>
 
   <!--<p>If the storage area space limit is reached during a <code
   data-x="dom-Storage-setItem">setItem()</code> call, the method will throw an exception.</p>-->
 
-  <p>通常建议每个 <span data-x="origin">域</span> 5M 的限制。
-  欢迎具体实现的反馈，用于将来更新这个建议。</p>
+  <p>通常建议每个 <span data-x="origin">源</span> 的存储上线是 5M。
+  欢迎实现者提供反馈意见，用于将来更新这个建议。</p>
 
-  <p>为了可预见性，应该根据未压缩的数据大小来进行配额。</p>
+  <p>为了保证可预测性，配额应该基于未压缩的数据存储大小来进行计算。</p>
   <!-- see https://www.w3.org/Bugs/Public/show_bug.cgi?id=21319#c3 -->
 
 


### PR DESCRIPTION
修正了关于附属站点的翻译错误；
修正了术语 `origin` 的翻译，我认为 `origin` 应该翻译成 `源`，`域` 对应的是 `domain`；
第一次参与贡献本项目，不知团队是否有微信群之类的群组用于交流？
有些术语翻译的一致性有待商榷。